### PR TITLE
Support fake extensions in RVConfig

### DIFF
--- a/src/main/scala/rvspeccore/core/RiscvCore.scala
+++ b/src/main/scala/rvspeccore/core/RiscvCore.scala
@@ -122,13 +122,13 @@ class RiscvCore()(implicit config: RVConfig) extends BaseCore with RVInstSet {
     iFetchpc := resultPC
 
     // Decode and Excute
-    config match {
-      case RV32Config(_) => {
+    config.XLEN match {
+      case 32 => {
         doRV32I
         if (config.M) { doRV32M }
         if (config.C) { doRV32C }
       }
-      case RV64Config(_) => {
+      case 64 => {
         doRV64I
         if (config.M) { doRV64M }
         if (config.C) { doRV64C }

--- a/src/test/scala/rvspeccore/checker/CheckerSpec.scala
+++ b/src/test/scala/rvspeccore/checker/CheckerSpec.scala
@@ -10,7 +10,7 @@ import rvspeccore.core._
 class CheckerWithResultSpec extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "CheckerWithResult"
 
-  implicit val config = RV64Config()
+  implicit val config = RVConfig(64)
 
   class TestCore(checkMem: Boolean = true) extends RiscvCore {
     val checker = Module(new CheckerWithResult(checkMem))
@@ -71,7 +71,7 @@ class CheckerWithResultSpec extends AnyFlatSpec with ChiselScalatestTester {
 class CheckerWithWBSpec extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "CheckerWithWB"
 
-  implicit val config = RV64Config()
+  implicit val config = RVConfig(64)
 
   class TestCore(checkMem: Boolean = true) extends RiscvCore {
     val wb = Wire(new WriteBack)

--- a/src/test/scala/rvspeccore/checker/ConnectHelperSpec.scala
+++ b/src/test/scala/rvspeccore/checker/ConnectHelperSpec.scala
@@ -10,7 +10,7 @@ import rvspeccore.core._
 class ConnectHelperSpec extends AnyFlatSpec with ChiselScalatestTester {
   behavior of "ConnectHelper"
 
-  implicit val config = RV64Config()
+  implicit val config = RVConfig(64)
 
   class TestCore extends RiscvCore {
     val checker = Module(new CheckerWithResult(false))


### PR DESCRIPTION
This will allow unsupported instruction set extensions to appear in misa.