### PR TITLE
Support multiple Chisel versions via compile options

### DIFF
--- a/.github/workflows/CrossVersionTest.yml
+++ b/.github/workflows/CrossVersionTest.yml
@@ -1,0 +1,21 @@
+name: CrossVersionTest
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Cross Version Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.8
+      - name: Cache Scala
+        uses: coursier/cache-action@v5
+      - name: Chisel3 publishLocal Test
+        run: sbt publishLocal -DChiselVersion=3.6.0
+      - name: Chisel6 publishLocal Test
+        run: sbt publishLocal -DChiselVersion=6.4.0 -DScalaVersion=2.13.12

--- a/.github/workflows/CrossVersionTest.yml
+++ b/.github/workflows/CrossVersionTest.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Cross Version Test
+    name: Cross version publishLocal test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -15,7 +15,11 @@ jobs:
           java-version: adopt@1.8
       - name: Cache Scala
         uses: coursier/cache-action@v5
+      - name: Defalut publishLocal Test
+        run: sbt publishLocal
       - name: Chisel3 publishLocal Test
         run: sbt publishLocal -DChiselVersion=3.6.0
       - name: Chisel6 publishLocal Test
         run: sbt publishLocal -DChiselVersion=6.4.0 -DScalaVersion=2.13.12
+      - name: Chisel7 publishLocal Test
+        run: sbt publishLocal -DChiselVersion=7.0.0-M2 -DScalaVersion=2.13.12

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -58,8 +58,9 @@ libraryDependencies += "cn.ac.ios.tis" %% "riscvspeccore" % "1.3-8bb84f4-SNAPSHO
 [info]  published ivy to ~/.ivy2/local/cn.ac.ios.tis/riscvspeccore_2.13/<strong>1.3-chisel7.0.0-m2-8bb84f4+-SNAPSHOT</strong>/ivys/ivy.xml
 ...</code></pre>
 
-
 #### 编译参数
+
+在 `sbt publishLocal` 命令后可以添加参数，配置版本信息和依赖的 Chisel 版本：
 
 `-DHashId=true` 在版本号中显示当前 Git HashId
 
@@ -287,7 +288,8 @@ assume(RVI.ADDI(inst) || RVI.ADD(inst))
 
 待验证处理器和参考模型连接之后，可以使用测试方法，也可以使用形式化验证在约束的范围内进行检查。
 
-下面通过 ChiselTest 对连接好参考模型的 `DUT` 进行形式化验证，调用了
+下面通过 [ChiselTest](https://github.com/ucb-bar/chiseltest)
+对连接好参考模型的 `DUT` 进行形式化验证，调用了
 [BtorMC](https://github.com/Boolector/btor2tools)
 模型检测工具，使用 BMC 算法检查了 12 个时钟周期内的指令集一致性：
 
@@ -306,6 +308,12 @@ class DUTFormalSpec extends AnyFlatSpec with Formal with ChiselScalatestTester {
   }
 }
 ```
+
+Chisel3.6/Chisel6 经过测试可以使用对应的 ChiselTest 完成上述验证。
+由于 ChiselTest 重放反例中的问题，可能会出现
+`ERROR: Constraint #assume was violated!  Warn: Potential simulation/formal mismatch.`
+等信息，不影响验证结果。  
+Chisel7 没有对应版本的 ChiselTest，暂不支持通过 BTOR2 格式的形式化验证。
 
 ## 使用建议
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,9 +12,9 @@ lazy val chiselVersion: Map[String, ModuleID] = {
       )
     case x if x.startsWith("6") =>
       Map(
-        "chisel"     -> "edu.berkeley.cs" %% "chisel3"        % x,
-        "chiseltest" -> "edu.berkeley.cs" %% "chiseltest"     % "6.0.0",
-        "plugin"     -> "edu.berkeley.cs"  % "chisel3-plugin" % x
+        "chisel"     -> "org.chipsalliance" %% "chisel"        % x,
+        "chiseltest" -> "edu.berkeley.cs"   %% "chiseltest"    % "6.0.0",
+        "plugin"     -> "org.chipsalliance"  % "chisel-plugin" % x
       )
     case "cha" =>
       Map(

--- a/build.sbt
+++ b/build.sbt
@@ -1,27 +1,54 @@
-// use `-DCHA=true` to use CHA version Chisel
-lazy val useCHA: Boolean =
-  sys.props.getOrElse("CHA", "false").toLowerCase == "true"
-// use `-DHashId=true` to include git hash id in the version number
-lazy val useHashId: Boolean =
-  sys.props.getOrElse("HashId", "false").toLowerCase == "true"
+// use `-DChiselVersion=3.x.x/6.x.x/CHA` to specify the version of Chisel
+lazy val chiselVersion: Map[String, ModuleID] = {
+  sys.props.getOrElse("ChiselVersion", "3.6.0").toLowerCase match {
+    case x if x.startsWith("3") =>
+      Map(
+        "chisel"     -> "edu.berkeley.cs" %% "chisel3"        % x,
+        "chiseltest" -> "edu.berkeley.cs" %% "chiseltest"     % "0.6.0",
+        "plugin"     -> "edu.berkeley.cs"  % "chisel3-plugin" % x
+      )
+    case x if x.startsWith("6") =>
+      Map(
+        "chisel"     -> "edu.berkeley.cs" %% "chisel3"        % x,
+        "chiseltest" -> "edu.berkeley.cs" %% "chiseltest"     % "6.0.0",
+        "plugin"     -> "edu.berkeley.cs"  % "chisel3-plugin" % x
+      )
+    case "cha" =>
+      Map(
+        "chisel"     -> "cn.ac.ios.tis" %% "chisel3"        % "3.7-SNAPSHOT",
+        "chiseltest" -> "cn.ac.ios.tis" %% "chiseltest"     % "0.7-SNAPSHOT",
+        "plugin"     -> "cn.ac.ios.tis"  % "chisel3-plugin" % "3.7-SNAPSHOT"
+      )
+    case _ => throw new Exception("chiselVersion should be one of 3.x.x, 6.x.x, CHA")
+  }
+}
 
+// use `-DHashId=true` to include git hash id in the version number
 ThisBuild / version := {
   val versionNumber = "1.3"
   val snapshot      = "-SNAPSHOT"
 
+  val chiselVersionTag: String = {
+    sys.props.getOrElse("ChiselVersion", "").toLowerCase match {
+      case ""    => ""
+      case "cha" => "-cha"
+      case x     => s"-chisel$x"
+    }
+  }
   val hashId = {
-    val hash = git.gitHeadCommit.value.getOrElse("unknown").take(7)
-    if (git.gitUncommittedChanges.value) s"-$hash+"
-    else s"-$hash"
+    val useHashId = sys.props.getOrElse("HashId", "false").toLowerCase == "true"
+    val hash      = git.gitHeadCommit.value.map(_.take(7)).getOrElse("unknown")
+    if (useHashId)
+      if (git.gitUncommittedChanges.value) s"-$hash+"
+      else s"-$hash"
+    else ""
   }
 
-  versionNumber +
-    (if (useCHA) "-cha" else "") +
-    (if (useHashId) hashId else "") +
-    snapshot
+  versionNumber + chiselVersionTag + hashId + snapshot
 }
 ThisBuild / organization := "cn.ac.ios.tis"
-ThisBuild / scalaVersion := "2.12.17"
+// use `-DScalaVersion=2.12.17/orOther` to specify the version of Scala
+ThisBuild / scalaVersion := sys.props.getOrElse("ScalaVersion", "2.12.17")
 // Use Scala2.13 with ChiselTest0.6.0 will cause efficiency issues in the
 // simulation. Here use Scala2.12 and ChiselTest0.6.0 to avoid this problem.
 
@@ -56,16 +83,10 @@ lazy val root = (project in file("."))
   .settings(
     name := "RiscvSpecCore",
     libraryDependencies ++= {
-      if (useCHA)
-        Seq(
-          "cn.ac.ios.tis" %% "chisel3"    % "3.7-SNAPSHOT",
-          "cn.ac.ios.tis" %% "chiseltest" % "0.7-SNAPSHOT" % "test"
-        )
-      else
-        Seq(
-          "edu.berkeley.cs" %% "chisel3"    % "3.6.0",
-          "edu.berkeley.cs" %% "chiseltest" % "0.6.0" % "test"
-        )
+      Seq(
+        chiselVersion("chisel"),
+        chiselVersion("chiseltest") % "test"
+      )
     },
     scalacOptions ++= Seq(
       "-language:reflectiveCalls",
@@ -74,7 +95,6 @@ lazy val root = (project in file("."))
       "-Xcheckinit"
     ),
     addCompilerPlugin(
-      if (useCHA) "cn.ac.ios.tis" % "chisel3-plugin" % "3.7-SNAPSHOT" cross CrossVersion.full
-      else "edu.berkeley.cs"      % "chisel3-plugin" % "3.6.0" cross CrossVersion.full
+      chiselVersion("plugin") cross CrossVersion.full
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,7 @@
 // use `-DChiselVersion=3.x.x/6.x.x/CHA` to specify the version of Chisel
+// use `-DHashId=true` to include git hash id in the version number
+// use `-DScalaVersion=2.12.17/orOther` to specify the version of Scala
+
 lazy val chiselVersion: Map[String, ModuleID] = {
   sys.props.getOrElse("ChiselVersion", "3.6.0").toLowerCase match {
     case x if x.startsWith("3") =>
@@ -23,7 +26,6 @@ lazy val chiselVersion: Map[String, ModuleID] = {
   }
 }
 
-// use `-DHashId=true` to include git hash id in the version number
 ThisBuild / version := {
   val versionNumber = "1.3"
   val snapshot      = "-SNAPSHOT"
@@ -47,7 +49,6 @@ ThisBuild / version := {
   versionNumber + chiselVersionTag + hashId + snapshot
 }
 ThisBuild / organization := "cn.ac.ios.tis"
-// use `-DScalaVersion=2.12.17/orOther` to specify the version of Scala
 ThisBuild / scalaVersion := sys.props.getOrElse("ScalaVersion", "2.12.17")
 // Use Scala2.13 with ChiselTest0.6.0 will cause efficiency issues in the
 // simulation. Here use Scala2.12 and ChiselTest0.6.0 to avoid this problem.

--- a/build.sbt
+++ b/build.sbt
@@ -1,28 +1,28 @@
-// use `-DChiselVersion=3.x.x/6.x.x/CHA` to specify the version of Chisel
+// use `-DChiselVersion=3.x.x/6.x.x/7.x.x/CHA` to specify the version of Chisel
 // use `-DHashId=true` to include git hash id in the version number
 // use `-DScalaVersion=2.12.17/orOther` to specify the version of Scala
 
 lazy val chiselVersion: Map[String, ModuleID] = {
-  sys.props.getOrElse("ChiselVersion", "3.6.0").toLowerCase match {
+  sys.props.getOrElse("ChiselVersion", "3.6.0") match {
     case x if x.startsWith("3") =>
       Map(
         "chisel"     -> "edu.berkeley.cs" %% "chisel3"        % x,
         "chiseltest" -> "edu.berkeley.cs" %% "chiseltest"     % "0.6.0",
         "plugin"     -> "edu.berkeley.cs"  % "chisel3-plugin" % x
       )
-    case x if x.startsWith("6") =>
+    case x if x.startsWith("6") || x.startsWith("7") =>
       Map(
         "chisel"     -> "org.chipsalliance" %% "chisel"        % x,
         "chiseltest" -> "edu.berkeley.cs"   %% "chiseltest"    % "6.0.0",
         "plugin"     -> "org.chipsalliance"  % "chisel-plugin" % x
       )
-    case "cha" =>
+    case "CHA" =>
       Map(
         "chisel"     -> "cn.ac.ios.tis" %% "chisel3"        % "3.7-SNAPSHOT",
         "chiseltest" -> "cn.ac.ios.tis" %% "chiseltest"     % "0.7-SNAPSHOT",
         "plugin"     -> "cn.ac.ios.tis"  % "chisel3-plugin" % "3.7-SNAPSHOT"
       )
-    case _ => throw new Exception("chiselVersion should be one of 3.x.x, 6.x.x, CHA")
+    case _ => throw new Exception("chiselVersion should be one of 3.x.x, 6.x.x, 7.x.x, CHA")
   }
 }
 


### PR DESCRIPTION
Users can specify Chisel and Scala versions with compile options like `-DChiselVersion=6.4.0` and `-DScalaVersion=2.13.12`.